### PR TITLE
Add qualifier to DriversSeat in TCK

### DIFF
--- a/src/main/java/org/atinject/tck/auto/DriversSeat.java
+++ b/src/main/java/org/atinject/tck/auto/DriversSeat.java
@@ -20,6 +20,7 @@ import jakarta.inject.Inject;
 
 import org.atinject.tck.auto.accessories.Cupholder;
 
+@Drivers
 public class DriversSeat extends Seat {
 
     @Inject


### PR DESCRIPTION
This qualifier is required as part of the test configuration, putting it here means it is part of the codebase and not from how the implementation configures the TCK runner.